### PR TITLE
Forward reference dataset and retrieve URL for input params

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -120,9 +120,7 @@ class BlockParser:
             "participants": (helper.handle_participants),
             "compute-envs": (helper.handle_compute_envs),
             "pipelines": (helper.handle_pipelines),
-            "launch": lambda sp, args: helper.handle_generic_block(
-                sp, "launch", args, method_name=None
-            ),
+            "launch": (helper.handle_launch),
         }
 
         # Check if overwrite is set to True, and call overwrite handler

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -298,6 +298,11 @@ def handle_generic_block(sp, block, args, method_name="add"):
         method(method_name, *args)
 
 
+def handle_launch(sp, args):
+    updated_args = utils.update_dataset_params(sp, args)
+    sp.launch(*updated_args)
+
+
 def handle_teams(sp, args):
     cmd_args, members_cmd_args = args
     sp.teams("add", *cmd_args)
@@ -335,7 +340,8 @@ def handle_pipelines(sp, args):
         # Check if arg is a url or a json file.
         # If it is, use the appropriate method and break.
         if utils.is_url(arg):
-            method("add", *args)
+            updated_args = utils.update_dataset_params(sp, args)
+            method("add", *updated_args)
             break
         elif ".json" in arg:
             method("import", *args)


### PR DESCRIPTION
Re #116 

Testing out functionality to retrieve the dataset URL referencing a dataset name using YAML anchor and provide URL as `input` param in params-file.

To test:
```yaml
datasets:
  - name: &dataset 'test-sqkit-dataset'
    file-path: './examples/yaml/datasets/rnaseq_samples.csv'
    description: 'My test dataset'
    workspace: 'scidev/testing'
    overwrite: True
launch:
  - name: "nf-core-rnaseq"
    pipeline: "nf-core-rnaseq"
    workspace: 'scidev/testing'
    params:
      input: *dataset 
```

This YAML creates a dataset, where the name is used as an anchor and the alias is referenced in the `params` block. The `utils.update_dataset_params()` method will retrieve the appropriate URL for the dataset to be used when launching a pipeline, or adding it to the Launchpad.

TODO:

- [ ] Add docs on usage
- [ ] Add tests