### PR TITLE
feat: Handle multiple workspaces when using overwrite behaviour

### DIFF
--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -296,7 +296,6 @@ class Overwrite:
             "labels",
             "data-links",
         }:
-            # TODO: this needs to include the organization or be based on workspace ID
             if sp_args.get("workspace"):
                 cache_key = f"{block}:{sp_args['workspace']}"
         elif block in {"members", "workspaces", "teams"}:

--- a/tests/unit/test_overwrite.py
+++ b/tests/unit/test_overwrite.py
@@ -260,6 +260,41 @@ class TestOverwrite(unittest.TestCase):
         with self.assertRaises(ResourceExistsError):
             self.overwrite.handle_overwrite("credentials", args, overwrite=False)
 
+    def test_multi_workspace_resource_check(self):
+        """Test that resources are correctly tracked per workspace."""
+        # Setup mock responses for two different workspaces
+        workspace1_json = json.dumps({"name": "resource-in-workspace1"})
+        workspace2_json = json.dumps({"name": "resource-in-workspace2"})
+
+        # Configure mock to return different data based on workspace
+        def mock_json_response(*args, **kwargs):
+            if args[3] == "workspace1":
+                return workspace1_json
+            elif args[3] == "workspace2":
+                return workspace2_json
+            return json.dumps({})
+
+        json_method_mock = Mock(side_effect=mock_json_response)
+        self.mock_sp.configure_mock(**{"-o json": json_method_mock})
+
+        # Check first workspace - should find resource-in-workspace1
+        args1 = ["--name", "resource-in-workspace1", "--workspace", "workspace1"]
+        with self.assertRaises(ResourceExistsError):
+            self.overwrite.handle_overwrite("credentials", args1)
+
+        # Should find resource-in-workspace2, not resource-in-workspace1
+        args2 = ["--name", "resource-in-workspace1", "--workspace", "workspace2"]
+        self.overwrite.handle_overwrite("credentials", args2)  # Should not raise error
+
+        # Verify both workspaces were queried
+        json_method_mock.assert_any_call("credentials", "list", "-w", "workspace1")
+        json_method_mock.assert_any_call("credentials", "list", "-w", "workspace2")
+
+        # Check a resource that exists in workspace2
+        args3 = ["--name", "resource-in-workspace2", "--workspace", "workspace2"]
+        with self.assertRaises(ResourceExistsError):
+            self.overwrite.handle_overwrite("credentials", args3)
+
 
 # TODO: tests for destroy and JSON caching
 


### PR DESCRIPTION
The overwrite behaviour ignored using multiple workspaces because the cached data just cached the contents and not the workspace ID. In this commit we add the workspace name to the key which will semi-uniqueify the cache and force an overwrite.

To do:
 - [x] ~currently it uses the workspace name, which is **not** unique. We should use workspace ID or organization and workspace.~ Actually, workspace is in the format organization/workspace so I think this should work OK.