### PR TITLE
feat: Remove null values from YAML input files

### DIFF
--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -199,7 +199,10 @@ def parse_block(block_name, item, sp=None):
 def parse_generic_block(item, sp=None):
     cmd_args = []
     for key, value in item.items():
-        if isinstance(value, bool):
+        # Skip None values
+        if value is None:
+            continue
+        elif isinstance(value, bool):
             if value:
                 cmd_args.append(f"--{key}")
         else:
@@ -218,12 +221,15 @@ def parse_type_block(item, priority_keys=["type", "config-mode", "file-path"], s
 
     # Process priority keys first
     for key in priority_keys:
-        if key in item:
+        if key in item and item[key] is not None:
             cmd_args.append(str(item[key]))
             del item[key]  # Remove the key to avoid repeating in args
 
     for key, value in item.items():
-        if isinstance(value, bool):
+        # Skip None values
+        if value is None:
+            continue
+        elif isinstance(value, bool):
             if value:
                 cmd_args.append(f"--{key}")
         elif key == "params":
@@ -243,6 +249,9 @@ def parse_teams_block(item, sp=None):
     members_cmd_args = []
 
     for key, value in item.items():
+        # Skip None values
+        if value is None:
+            continue
         if key in cmd_keys:
             cmd_args.extend([f"--{key}", str(value)])
         elif key in members_keys and key == "members":
@@ -264,6 +273,9 @@ def parse_teams_block(item, sp=None):
 def parse_datasets_block(item, sp=None):
     cmd_args = []
     for key, value in item.items():
+        # Skip None values
+        if value is None:
+            continue
         if key == "file-path":
             cmd_args.extend(
                 [
@@ -340,7 +352,7 @@ def process_params_dict(params_dict, workspace=None, sp=None, params_file_path=N
         if sp is not None and workspace:
             params_dict = resolve_dataset_reference(params_dict, workspace, sp)
 
-        # Create temp file with resolved params
+        # Create temp file with params
         temp_file_name = utils.create_temp_yaml(
             params_dict, params_file=params_file_path
         )
@@ -357,6 +369,9 @@ def parse_pipelines_block(item, sp=None):
     repo_args = []
 
     for key, value in item.items():
+        # Skip None values
+        if value is None:
+            continue
         if key == "url":
             repo_args.extend([str(value)])
         elif key == "params":
@@ -383,6 +398,9 @@ def parse_launch_block(item, sp=None):
     repo_args = []
 
     for key, value in item.items():
+        # Skip None values
+        if value is None:
+            continue
         if key == "pipeline" or key == "url":
             repo_args.extend([str(value)])
         elif key in ["params", "params-file"]:

--- a/seqerakit/utils.py
+++ b/seqerakit/utils.py
@@ -141,6 +141,9 @@ def create_temp_yaml(params_dict, params_file=None):
 
     combined_params.update(params_dict)
 
+    # Filter out None values but keep empty strings
+    combined_params = {k: v for k, v in combined_params.items() if v is not None}
+
     for key, value in combined_params.items():
         if isinstance(value, str):
             resolved_value = resolve_env_var(value)

--- a/tests/unit/test_seqeraplatform.py
+++ b/tests/unit/test_seqeraplatform.py
@@ -96,12 +96,8 @@ class TestSeqeraPlatform(unittest.TestCase):
 
     def test_empty_string_argument(self):
         command = ["--profile", " ", "--config", "my_config"]
-        with self.assertRaises(ValueError) as context:
-            self.sp._check_empty_args(command)
-        self.assertIn(
-            "Empty string argument found for parameter '--profile'",
-            str(context.exception),
-        )
+        parsed_command = self.sp._check_empty_args(command)
+        self.assertEqual(parsed_command, ["--config", "my_config"])
 
     def test_no_empty_string_argument(self):
         command = ["--profile", "test_profile", "--config", "my_config"]


### PR DESCRIPTION
When seqerakit encounters a null or None value when submitting tower-cli commands, it will skip and bypass those options to the tower-cli and therefore support can ignore empty values

This will fix #212