### PR TITLE
fix: on_exists inside YAML files is respected

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -39,7 +39,9 @@ logger = logging.getLogger(__name__)
 
 def parse_args(args=None):
     parser = argparse.ArgumentParser(
-        description="Create resources on Seqera Platform using a YAML configuration file."
+        description="""
+        Create resources on Seqera Platform using a YAML configuration file.
+        """
     )
     # General options
     general = parser.add_argument_group("General Options")
@@ -191,7 +193,9 @@ class BlockParser:
         # If no global setting, use block-level setting if provided
         elif "on_exists" in args:
             on_exists_value = args["on_exists"]
-            if isinstance(on_exists_value, str):
+            if isinstance(on_exists_value, OnExists):
+                on_exists = on_exists_value
+            elif isinstance(on_exists_value, str):
                 try:
                     on_exists = OnExists[on_exists_value.upper()]
                 except KeyError as err:

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -458,6 +458,9 @@ def handle_pipelines(sp, args):
             break
         elif ".json" in arg:
             method("import", *args)
+            break
+    else:  # No break occurred
+        method("add", *args)
 
 
 def find_name(cmd_args):

--- a/seqerakit/overwrite.py
+++ b/seqerakit/overwrite.py
@@ -99,6 +99,14 @@ class Overwrite:
             },
         }
 
+        # Initialize the generic deletion handlers upfront
+        for block in self.generic_deletion:
+            self.block_operations[block] = {
+                "keys": ["name", "workspace"],
+                "method_args": self._get_generic_deletion_args,
+                "name_key": "name",
+            }
+
     def handle_overwrite(
         self, block, args, on_exists=OnExists.FAIL, destroy=False, overwrite=None
     ):
@@ -128,13 +136,6 @@ class Overwrite:
         # For backward compatibility
         if overwrite is not None:
             on_exists = OnExists.OVERWRITE if overwrite else OnExists.FAIL
-
-        if block in Overwrite.generic_deletion:
-            self.block_operations[block] = {
-                "keys": ["name", "workspace"],
-                "method_args": self._get_generic_deletion_args,
-                "name_key": "name",
-            }
 
         if block in self.block_operations:
             operation = self.block_operations[block]


### PR DESCRIPTION
The `on_exists` field in the YAML was being ignored by seqerakit because it was bypassed by the code path. This PR just reorders some stuff and fixes the issue.