### PR TITLE
fix: support for updating member roles in orgs

### DIFF
--- a/seqerakit/cli.py
+++ b/seqerakit/cli.py
@@ -166,6 +166,7 @@ class BlockParser:
         # Handles a block of commands by calling the appropriate function.
         block_handler_map = {
             "teams": (helper.handle_teams),
+            "members": (helper.handle_members),
             "participants": (helper.handle_participants),
             "compute-envs": (helper.handle_compute_envs),
             "pipelines": (helper.handle_pipelines),
@@ -321,7 +322,6 @@ def main(args=None):
             "organizations",  # all use method.add
             "workspaces",
             "labels",
-            "members",
             "credentials",
             "secrets",
             "actions",

--- a/seqerakit/helper.py
+++ b/seqerakit/helper.py
@@ -481,6 +481,26 @@ def handle_pipelines(sp, args):
         method("add", *args)
 
 
+def handle_members(sp, args):
+    method = getattr(sp, "members")
+
+    # Check if role is specified in args
+    has_role = "--role" in args
+    role_value = None
+
+    if has_role:
+        role_index = args.index("--role")
+        role_value = args[role_index + 1]
+        args = [
+            arg for i, arg in enumerate(args) if i != role_index and i != role_index + 1
+        ]
+    method("add", *args)
+
+    # Then update with role if provided
+    if has_role and role_value:
+        method("update", *args, "--role", role_value)
+
+
 def find_name(cmd_args):
     """
     Find and return the value associated with --name in cmd_args, where cmd_args


### PR DESCRIPTION
Fixes #221, if a `role` is specified for `members`, we will run the `add` method follow by `update`. 

Example:

```yaml
members:
   - user: 'adam.talbot@seqera.io'
     organization: 'scidev'
     role: 'member'
     on_exists: overwrite

```

```console
seqerakit members.yml 
INFO:root: Running command: tw -o json members list -o scidev
INFO:root: Checking if email adam.talbot@seqera.io exists in Seqera Platform...
INFO:root: Running command: tw members add --user adam.talbot@seqera.io --organization scidev
INFO:root: Command output: Member 'adamtalbot' with ID '262639818524125' was added in organization 'scidev'
Member 'adamtalbot' with ID '262639818524125' was added in organization 'scidev'
INFO:root: Running command: tw members update --user adam.talbot@seqera.io --organization scidev --role member
INFO:root: Command output: Member 'adam.talbot@seqera.io' updated to role 'member' in organization 'scidev'
Member 'adam.talbot@seqera.io' updated to role 'member' in organization 'scidev'
```